### PR TITLE
Fix progress suppression parameter

### DIFF
--- a/plugins/Blender/Blender.py
+++ b/plugins/Blender/Blender.py
@@ -150,12 +150,12 @@ class BlenderPlugin(DeadlinePlugin):
         progress = progress / float( self.totalFrames )
         self.SetProgress( progress * 100 )
         
-        if self.GetBooleanPluginInfoEntryWithDefault( "SupressOutput", True ):
+        if self.GetBooleanPluginInfoEntryWithDefault( "SuppressOutput", True ):
             self.SuppressThisLine()
         
     def HandleStdoutSaved(self):
         self.finishedFrames += 1
-        self.currentChunk = 0 # Avoid incorrect progress math after addtion
+        self.currentChunk = 0 # Avoid incorrect progress math after addition
         
         self.UpdateProgress()
         


### PR DESCRIPTION
## Summary
- fix typo in parameter name for suppressing verbose output
- fix small comment typo

## Testing
- `python3 -m py_compile plugins/Blender/Blender.py scripts/Submission/BlenderSubmission.py`

------
https://chatgpt.com/codex/tasks/task_e_684051044ea48330af674ef43fc0d973